### PR TITLE
Remove reference of poor error message as mistake

### DIFF
--- a/content/learn/make-survey.md
+++ b/content/learn/make-survey.md
@@ -8,7 +8,7 @@ hero: "Create a pol.is survey in a few easy steps and learn what your community 
 
 [Create a free account](https://pol.is/createuser). If you have more than one team member or collaborator, you will need to share the account.
 
-_Whoops! Mistakes happen. If you see 'bad request' while creating an account, please choose a longer password._
+_If you see 'Bad Request' while creating an account, please choose a longer password._
 
 ## Step 2
 


### PR DESCRIPTION
Hiya! Was just going through the site and came across this copy that felt like it might be candidate for alternative phrasing :)

I love the casual voice of the copy, but since most people have passwords longer than the minimum, I thought it might make sense to de-emphasize the nature of the issue, as the vast majority of people wont encounter it :) Since the trust people have of the pol.is platform is tightly connected to our own initiative, it might make sense to preserve trust by avoiding phrasing like the current one in favour of something more like a helpful note.

Maybe even this:

> Reminder: Use a strong password of at least X characters. (Short passwords will result in a "Bad Request" error.)

In the meantime, I created a ticket to resolve the vague error message, and then we can just remove our little note :) https://github.com/pol-is/issues/issues/62